### PR TITLE
Add Firefox timelapsify extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Timelapsify Firefox Extension
+
+This repository contains a minimal Firefox extension and a Python native
+messaging host that downloads the current YouTube video and plays it back as a
+timelapse at a selected speed (2x–50x).
+
+## Usage
+
+1. Install `yt-dlp` and `ffmpeg` on your system.
+2. Copy `timelapsify.py` somewhere on your system and create a native
+   messaging host manifest pointing to it. For example on Linux:
+   `~/.mozilla/native-messaging-hosts/timelapsify.json`:
+
+```json
+{
+  "name": "timelapsify",
+  "description": "Timelapse helper",
+  "path": "/path/to/timelapsify.py",
+  "type": "stdio",
+  "allowed_extensions": ["timelapsify@example.com"]
+}
+```
+
+3. Load the `extension/` directory as a temporary add-on in Firefox.
+4. Open any YouTube video, click the extension button, choose your speed and
+   press **Create Timelapse**. The video will be downloaded, processed, and
+   played without sound.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,1 @@
+// Empty background script to enable native messaging

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,26 @@
+{
+  "manifest_version": 2,
+  "name": "Timelapsify",
+  "version": "1.0",
+  "description": "Download and play YouTube videos as a timelapse.",
+  "permissions": [
+    "activeTab",
+    "tabs",
+    "nativeMessaging"
+  ],
+  "browser_action": {
+    "default_title": "Timelapsify",
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "scripts": [
+      "background.js"
+    ],
+    "persistent": false
+  },
+  "applications": {
+    "gecko": {
+      "id": "timelapsify@example.com"
+    }
+  }
+}

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    body { font-family: Arial, sans-serif; width: 200px; padding: 10px; }
+    #speedLabel { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h3>Timelapsify</h3>
+  <input type="range" id="speedRange" min="2" max="50" value="2">
+  <div id="speedLabel">Speed: 2x</div>
+  <button id="timelapseBtn">Create Timelapse</button>
+  <div id="status"></div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -1,0 +1,19 @@
+document.getElementById('speedRange').addEventListener('input', function(e) {
+  document.getElementById('speedLabel').textContent = `Speed: ${e.target.value}x`;
+});
+
+document.getElementById('timelapseBtn').addEventListener('click', async () => {
+  const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+  if (!tab || !tab.url.includes('youtube.com/watch')) {
+    document.getElementById('status').textContent = 'Not a YouTube video.';
+    return;
+  }
+  const speed = document.getElementById('speedRange').value;
+  document.getElementById('status').textContent = 'Processing...';
+  try {
+    await browser.runtime.sendNativeMessage('timelapsify', { url: tab.url, speed: speed });
+    document.getElementById('status').textContent = 'Sent to host application.';
+  } catch (err) {
+    document.getElementById('status').textContent = 'Failed: ' + err;
+  }
+});

--- a/timelapsify.py
+++ b/timelapsify.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import json
+import sys
+import subprocess
+import tempfile
+import os
+
+def read_message():
+    raw_length = sys.stdin.buffer.read(4)
+    if len(raw_length) == 0:
+        return None
+    message_length = int.from_bytes(raw_length, byteorder='little')
+    message = sys.stdin.buffer.read(message_length).decode('utf-8')
+    return json.loads(message)
+
+def send_message(message):
+    encoded = json.dumps(message).encode('utf-8')
+    sys.stdout.buffer.write(len(encoded).to_bytes(4, byteorder='little'))
+    sys.stdout.buffer.write(encoded)
+    sys.stdout.flush()
+
+
+def process(url, speed):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        video_path = os.path.join(tmpdir, 'video.mp4')
+        cmd = ['yt-dlp', '-f', 'best', '-o', video_path, url]
+        subprocess.run(cmd, check=True)
+        output = os.path.join(tmpdir, 'timelapse.mp4')
+        ffmpeg_cmd = [
+            'ffmpeg', '-y', '-i', video_path,
+            '-filter:v', f'setpts=PTS/{speed}',
+            '-an', output
+        ]
+        subprocess.run(ffmpeg_cmd, check=True)
+        subprocess.Popen(['xdg-open', output])
+
+if __name__ == '__main__':
+    msg = read_message()
+    if not msg:
+        sys.exit(0)
+    url = msg.get('url')
+    speed = msg.get('speed', '2')
+    try:
+        process(url, speed)
+        send_message({'status': 'ok'})
+    except Exception as e:
+        send_message({'status': 'error', 'message': str(e)})


### PR DESCRIPTION
## Summary
- add minimal Firefox extension for timelapsing YouTube videos
- include native messaging Python host that uses yt-dlp and ffmpeg
- document usage and host manifest setup in README

## Testing
- `python3 -m py_compile timelapsify.py`


------
https://chatgpt.com/codex/tasks/task_e_685a2f6efc208330a90146d6ff1f0929